### PR TITLE
Update magellan-proxy 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.13 (2016-06-xx)
+## 0.1.13 (2016-06-16)
 
  * Update magellan-proxy to 0.1.5
  * Added environment variable `TIMEZONE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.13 (2016-06-xx)
 
  * Update magellan-proxy to 0.1.5
+ * Added environment variable `MAGELLAN_PROXY_TIMEZONE`
  * Install stackprof gem to install latest flamegraph (v0.9.5)
 
 ## 0.1.12 (2016-05-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.13 (2016-06-xx)
 
  * Update magellan-proxy to 0.1.5
+ * Install stackprof gem to install latest flamegraph (v0.9.5)
 
 ## 0.1.12 (2016-05-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.13 (2016-06-xx)
+
+ * Update magellan-proxy to 0.1.5
+
 ## 0.1.12 (2016-05-09)
 
  * Upgrade docker-compose.yml format to version 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.1.13 (2016-06-xx)
 
  * Update magellan-proxy to 0.1.5
- * Added environment variable `MAGELLAN_PROXY_TIMEZONE`
+ * Added environment variable `TIMEZONE`
  * Install stackprof gem to install latest flamegraph (v0.9.5)
 
 ## 0.1.12 (2016-05-09)

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,12 @@ ENV RACK_MINI_PROFILER_ENABLED true
 ENV RUBY_GC_PROFILER_ENABLED true
 ENV TDIARY_BASIC_AUTH_USERNAME tdiary
 ENV TDIARY_BASIC_AUTH_PASSWORD tdiary
-ENV MAGELLAN_PROXY_TIMEZONE Asia/Tokyo
+ENV TIMEZONE Asia/Tokyo
 
 WORKDIR /usr/src/app
 
 ENTRYPOINT ["/opt/magellan-tdiary/entrypoint"]
-CMD [ "magellan-proxy", "-n", "5", "--timezone", "${MAGELLAN_PROXY_TIMEZONE}", \
+CMD [ "magellan-proxy", "-n", "5", \
       "bundle", "exec", "passenger", "start", "-p", "80", "-e", "production", "--max-pool-size", "3", \
       "--pid-file", "tmp/passenger.pid", "--load-shell-envvars", "--static-files-dir", "public" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,12 @@ ENV RACK_MINI_PROFILER_ENABLED true
 ENV RUBY_GC_PROFILER_ENABLED true
 ENV TDIARY_BASIC_AUTH_USERNAME tdiary
 ENV TDIARY_BASIC_AUTH_PASSWORD tdiary
+ENV MAGELLAN_PROXY_TIMEZONE Asia/Tokyo
 
 WORKDIR /usr/src/app
 
 ENTRYPOINT ["/opt/magellan-tdiary/entrypoint"]
-CMD [ "magellan-proxy", "-n", "5", \
+CMD [ "magellan-proxy", "-n", "5", "--timezone", "${MAGELLAN_PROXY_TIMEZONE}" \
       "bundle", "exec", "passenger", "start", "-p", "80", "-e", "production", "--max-pool-size", "3", \
       "--pid-file", "tmp/passenger.pid", "--load-shell-envvars", "--static-files-dir", "public" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV MAGELLAN_PROXY_TIMEZONE Asia/Tokyo
 WORKDIR /usr/src/app
 
 ENTRYPOINT ["/opt/magellan-tdiary/entrypoint"]
-CMD [ "magellan-proxy", "-n", "5", "--timezone", "${MAGELLAN_PROXY_TIMEZONE}" \
+CMD [ "magellan-proxy", "-n", "5", "--timezone", "${MAGELLAN_PROXY_TIMEZONE}", \
       "bundle", "exec", "passenger", "start", "-p", "80", "-e", "production", "--max-pool-size", "3", \
       "--pid-file", "tmp/passenger.pid", "--load-shell-envvars", "--static-files-dir", "public" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV TDIARY_CONTRIB_VERSION=v5.0.0
 ENV TDIARY_CACHE_NULL_VERSION=v0.1.2
 ENV TDIARY_IO_RDB_VERSION=v0.0.2
 ENV TDIARY_STYLE_GFM_VERSION=v0.3.0
+ENV MAGELLAN_PROXY_VERSION=0.1.5
 
 ## install tdiary-core to /usr/src/app
 RUN git clone -b ${TDIARY_CORE_VERSION} https://github.com/tdiary/tdiary-core.git /usr/src/app
@@ -28,7 +29,7 @@ RUN install -m 755 -o root -g root -p -D /build/entrypoint /opt/magellan-tdiary/
 RUN install -m 644 -o root -g root -p -D /build/Rakefile   /opt/magellan-tdiary/Rakefile
 
 ## install magellan-proxy
-ADD https://github.com/groovenauts/magellan-proxy/releases/download/v0.1.4/magellan-proxy-0.1.4_linux-amd64 /usr/local/bin/magellan-proxy
+ADD https://github.com/groovenauts/magellan-proxy/releases/download/v${MAGELLAN_PROXY_VERSION}/magellan-proxy-${MAGELLAN_PROXY_VERSION}_linux-amd64 /usr/local/bin/magellan-proxy
 RUN chmod +x /usr/local/bin/magellan-proxy
 
 ## cleanup

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ environment variable:
 
  * `RUBY_GC_PROFILER_ENABLED` (default: `true`)
 
+### magellan-proxy
+
+Options of [magellan-proxy](https://github.com/groovenauts/magellan-proxy)
+is configured by environment variables:
+
+ * `MAGELLAN_PROXY_TIMEZONE` (default: `Asia/Tokyo`)
+
 ## Local test with docker-compose
 
 You can try tDiary with docker-compose:

--- a/README.md
+++ b/README.md
@@ -80,12 +80,37 @@ environment variables:
 
  * `TIMEZONE` (default: `Asia/Tokyo`)
 
-## Local test with docker-compose
 
-You can try tDiary with docker-compose:
+## Development
+
+### Build
+
+You can build magellan-tdiary with docker-compose:
 
 ```
-% docker-compose up -d 
+% editor some-file               # Edit what you want
+% editor docker-compose.yml      # Edit tag of minimum2scp/magellan-tdiary image if necessary
+% docker-compose build tdiary
+```
+
+### Local test
+
+At first, if you want to use local build image, run:
+
+```
+% docker-compose build tdiary
+```
+
+Or pull image from [Docker Hub](https://hub.docker.com/r/minimum2scp/magellan-tdiary/):
+
+```
+% docker-compose pull tdiary
+```
+
+Then you can test magellan-tdiary with docker-compose:
+
+```
+% docker-compose up -d
 Creating magellantdiary_db_1...
 Creating magellantdiary_tdiary_1...
 Creating magellantdiary_nginx_1...
@@ -111,5 +136,4 @@ magellantdiary_tdiary_3   /opt/magellan-tdiary/entry ...   Up      80/tcp
 ```
 
 See docker-compose.yml for details.
-
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ environment variable:
 
 ### magellan-proxy
 
-Options of [magellan-proxy](https://github.com/groovenauts/magellan-proxy)
-is configured by environment variables:
+[magellan-proxy](https://github.com/groovenauts/magellan-proxy) is configured by
+environment variables:
 
- * `MAGELLAN_PROXY_TIMEZONE` (default: `Asia/Tokyo`)
+ * `TIMEZONE` (default: `Asia/Tokyo`)
 
 ## Local test with docker-compose
 

--- a/build/Gemfile.local
+++ b/build/Gemfile.local
@@ -11,6 +11,10 @@ gem "tdiary-io-rdb",           github: "tdiary/tdiary-io-rdb",          ref: ENV
 gem "tdiary-style-gfm",        github: "tdiary/tdiary-style-gfm",       ref: ENV["TDIARY_STYLE_GFM_VERSION"]
 
 gem "newrelic_rpm"
+
 gem "flamegraph"
+## flamegraph gem depends on stackprof or fast_stack gem
+gem "stackprof"
+
 gem "rack-mini-profiler", require: false
 

--- a/build/entrypoint
+++ b/build/entrypoint
@@ -1,7 +1,5 @@
 #! /usr/bin/env ruby
 
-require 'shellwords'
-
 if ENV['TDIARY_BASIC_AUTH_USERNAME'] && ENV['TDIARY_BASIC_AUTH_PASSWORD']
   system('rake -f /opt/magellan-tdiary/Rakefile htpasswd:create')
   ENV.delete('TDIARY_BASIC_AUTH_USERNAME')
@@ -16,4 +14,5 @@ if ENV['DATABASE_URL']
   system('rake -f /opt/magellan-tdiary/Rakefile db:create')
 end
 
-exec(Shellwords.join(ARGV))
+program = ARGV.shift
+exec(program, *ARGV)

--- a/build/entrypoint
+++ b/build/entrypoint
@@ -1,5 +1,7 @@
 #! /usr/bin/env ruby
 
+require 'shellwords'
+
 if ENV['TDIARY_BASIC_AUTH_USERNAME'] && ENV['TDIARY_BASIC_AUTH_PASSWORD']
   system('rake -f /opt/magellan-tdiary/Rakefile htpasswd:create')
   ENV.delete('TDIARY_BASIC_AUTH_USERNAME')
@@ -14,5 +16,4 @@ if ENV['DATABASE_URL']
   system('rake -f /opt/magellan-tdiary/Rakefile db:create')
 end
 
-program = ARGV.shift
-exec(program, *ARGV)
+exec(Shellwords.join(ARGV))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - ./volumes/nginx/tdiary.conf:/etc/nginx/conf.d/tdiary.conf:ro
 
   tdiary:
+    build:
+      context: .
     image: minimum2scp/magellan-tdiary:0.1.13
     command: >
       bundle exec passenger start -e production -p 80 --max-pool-size 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ./volumes/nginx/tdiary.conf:/etc/nginx/conf.d/tdiary.conf:ro
 
   tdiary:
-    image: minimum2scp/magellan-tdiary:0.1.12
+    image: minimum2scp/magellan-tdiary:0.1.13
     command: >
       bundle exec passenger start -e production -p 80 --max-pool-size 3
       --pid-file tmp/passenger.pid --load-shell-envvars --static-files-dir public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   nginx:
-    image: nginx:1.9
+    image: nginx:1.11
     volumes:
       - ./volumes/nginx/tdiary.conf:/etc/nginx/conf.d/tdiary.conf:ro
 


### PR DESCRIPTION
Updated magellan-proxy v0.1.5 and set timezone
by environment variable `TIMEZONE`, default is `Asia/Tokyo`.
See also: https://github.com/groovenauts/magellan-proxy/commit/a170c358c24f31dd8e977468ac79a0c64972e364

And fixed build error with latest stackprof (v0.9.5).

Other changes:
- added build section in docker-compose.yml
- updated nginx version to 1.11 in docker-compose.yml
